### PR TITLE
Use STL header <set> instead of the internal header <bits/stl_set.h>

### DIFF
--- a/Deploy/pe_type.cpp
+++ b/Deploy/pe_type.cpp
@@ -14,7 +14,7 @@
 #include <parser-library/parse.h>
 #include <quasarapp.h>
 
-#include <bits/stl_set.h>
+#include <set>
 
 namespace peparse {
 


### PR DESCRIPTION
Hi, thank you for your nice work. CQtDeployer made it easy for me to find the dll files that the Qt program depends on.

I found the header file `bits/stl_set.h` was used directly. It would be better if you use the standard library header `set`.

Please review and test my change. Thank you.